### PR TITLE
refactor getGroup/getGroups

### DIFF
--- a/federatedgroups/lib/AppInfo/Application.php
+++ b/federatedgroups/lib/AppInfo/Application.php
@@ -27,9 +27,9 @@ class Application extends App {
 		$container = $this->getContainer();
 		$server = $container->getServer();
 
-		$container->registerService('OCA\\FederatedGroups\\GroupBackend', function (SimpleContainer $c) use ($server) {
-			return new GroupBackend();
-		});
+		// $container->registerService('OCA\\FederatedGroups\\GroupBackend', function (SimpleContainer $c) use ($server) {
+		// 	return new GroupBackend();
+		// });
 
 		$container->registerService('ScimSecurityMiddleware', function($c) use($server){
             return new ScimSecurityMiddleware($server->getRequest(), $server->getConfig());

--- a/federatedgroups/lib/AppInfo/Application.php
+++ b/federatedgroups/lib/AppInfo/Application.php
@@ -27,10 +27,6 @@ class Application extends App {
 		$container = $this->getContainer();
 		$server = $container->getServer();
 
-		// $container->registerService('OCA\\FederatedGroups\\GroupBackend', function (SimpleContainer $c) use ($server) {
-		// 	return new GroupBackend();
-		// });
-
 		$container->registerService('ScimSecurityMiddleware', function($c) use($server){
             return new ScimSecurityMiddleware($server->getRequest(), $server->getConfig());
         });

--- a/federatedgroups/lib/Controller/ScimController.php
+++ b/federatedgroups/lib/Controller/ScimController.php
@@ -99,7 +99,6 @@ class ScimController extends Controller {
 
         $currentMembers =  $backend->usersInGroup($groupId);
 
-        // $currentMembers = $this->groupBackend->usersInGroup($groupId);
         $newMembers     = [];
         foreach ($obj["members"] as $member) {
             $userIdParts = explode("@", $member["value"]);
@@ -118,14 +117,12 @@ class ScimController extends Controller {
         foreach ($currentMembers as $currentMember) {
             if (!in_array($currentMember, $newMembers)) {
                 $backend->removeFromGroup($currentMember, $groupId);
-                // $this->groupBackend->removeFromGroup($currentMember, $groupId);
             }
         }
 
         foreach ($newMembers as $newMember) {
             if (!in_array($newMember, $currentMembers)) {
                 $backend->addToGroup($newMember, $groupId);
-                // $this->groupBackend->addToGroup($newMember, $groupId);
 
                 $newDomain = $this->getNewDomainIfNeeded($newMember, $currentMembers);
                 if ($newDomain) {
@@ -155,16 +152,11 @@ class ScimController extends Controller {
             $this->groupBackend->createGroup($id);
         }
 
-        // $group = new Group($id, [$this->groupBackend], $this->userManager, $this->eventDispatcher, $this->groupManager, $id);
-
-
         // expect group to already exist
         // we are probably receiving this create due to
         // https://github.com/SURFnet/rd-sram-integration/commit/38c6289fd85a92b7fce5d4fbc9ea3170c5eed5d5
         try {
             $this->handleUpdateGroup($id, $body);
-            // $groupData = $this->handleGetGroupData($id);
-            // return new JSONResponse(['status'  => 'success', 'message' => null, 'data' => $groupData], Http::STATUS_CREATED);
         } catch (\Exception $ex) {
             return new JSONResponse(['status' => 'error', 'message' => $ex->getMessage(), 'data' => null], Http::STATUS_BAD_REQUEST);
         }
@@ -195,8 +187,6 @@ class ScimController extends Controller {
 
         try {
             $this->handleUpdateGroup($groupId, $body);
-            // $groupData = $this->handleGetGroupData($groupId);
-            // return new JSONResponse(['status' => 'success', 'message' => null, 'data' => $groupData], Http::STATUS_OK);
         } catch (\Exception $ex) {
             return new JSONResponse(['status' => 'error', 'message' => $ex->getMessage(), 'data' => null], Http::STATUS_BAD_REQUEST);
         }

--- a/federatedgroups/lib/Controller/ScimController.php
+++ b/federatedgroups/lib/Controller/ScimController.php
@@ -154,6 +154,8 @@ class ScimController extends Controller {
         // https://github.com/SURFnet/rd-sram-integration/commit/38c6289fd85a92b7fce5d4fbc9ea3170c5eed5d5
         try {
             $this->handleUpdateGroup($id, $body);
+            // $groupData = $this->handleGetGroupData($id);
+            // return new JSONResponse(['status'  => 'success', 'message' => null, 'data' => $groupData], Http::STATUS_CREATED);
         } catch (\Exception $ex) {
             return new JSONResponse(['status' => 'error', 'message' => $ex->getMessage(), 'data' => null], Http::STATUS_BAD_REQUEST);
         }
@@ -184,6 +186,8 @@ class ScimController extends Controller {
 
         try {
             $this->handleUpdateGroup($groupId, $body);
+            // $groupData = $this->handleGetGroupData($groupId);
+            // return new JSONResponse(['status' => 'success', 'message' => null, 'data' => $groupData], Http::STATUS_OK);
         } catch (\Exception $ex) {
             return new JSONResponse(['status' => 'error', 'message' => $ex->getMessage(), 'data' => null], Http::STATUS_BAD_REQUEST);
         }

--- a/federatedgroups/lib/GroupManagerProxy.php
+++ b/federatedgroups/lib/GroupManagerProxy.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace OCA\FederatedGroups;
+
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+use OC\Hooks\PublicEmitter;
+use OC\Group\Group;
+use OCP\IGroupManager;
+use OC\User\Manager as UserManager;
+use OCP\ILogger;
+use OCA\FederatedGroups\GroupBackend;
+
+
+class GroupManagerProxy extends PublicEmitter
+{
+    /**
+     * @var \OC\Group\Group[]
+     */
+    private $cachedGroups = [];
+
+    /**
+     * @var \OC\Group\Group[]
+     */
+    private $cachedUserGroups = [];
+
+    private IGroupManager $groupManager;
+    private UserManager $userManager;
+    private EventDispatcherInterface $eventDispatcher;
+
+    private ILogger $logger;
+    private GroupBackend $groupBackend;
+
+
+
+    public function __construct(
+        IGroupManager $groupManager,
+        UserManager $userManager,
+        EventDispatcherInterface $eventDispatcher,
+        GroupBackend $groupBackend,
+        ILogger $logger
+    ) {
+
+        $this->groupManager = $groupManager;
+        $this->eventDispatcher = $eventDispatcher;
+
+        $this->userManager = $userManager;
+
+        $cachedGroups = &$this->cachedGroups;
+        $cachedUserGroups = &$this->cachedUserGroups;
+        $this->groupBackend = $groupBackend;
+        $this->logger = $logger;
+
+        $this->listen('\OC\Group', 'postDelete', function ($group) use (&$cachedGroups, &$cachedUserGroups) {
+            /**
+             * @var \OC\Group\Group $group
+             */
+            unset($cachedGroups[$group->getGID()]);
+            $cachedUserGroups = [];
+        });
+        $this->listen('\OC\Group', 'postAddUser', function ($group) use (&$cachedUserGroups) {
+            /**
+             * @var \OC\Group\Group $group
+             */
+            $cachedUserGroups = [];
+        });
+        $this->listen('\OC\Group', 'postRemoveUser', function ($group) use (&$cachedUserGroups) {
+            /**
+             * @var \OC\Group\Group $group
+             */
+            $cachedUserGroups = [];
+        });
+    }
+
+
+    /**
+     * @param string $gid
+     * @return \OC\Group\Group
+     */
+    public function createGroup($gid)
+    {
+        $this->groupBackend;
+        // error_log("jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj");
+        // $this->logger->info('Create Group ' . $gid . ' with members: ');
+        // var_export("jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj");
+
+        if ($gid === '' || $gid === null || \trim($gid) !== $gid) {
+            return false;
+        } elseif ($group = $this->get($gid)) {
+            return $group;
+        } else {
+            $this->emit('\OC\Group', 'preCreate', [$gid]);
+            $this->eventDispatcher->dispatch(new GenericEvent(null, ['gid' => $gid]), 'group.preCreate');
+
+            if ($this->groupBackend->implementsActions(\OC\Group\Backend::CREATE_GROUP)) {
+                /* @phan-suppress-next-line PhanUndeclaredMethod */
+                $created = $this->groupBackend->createGroup($gid);
+
+                if ($created) {
+                    $this->cachedGroups[$gid] = new Group($gid, [$this->groupBackend], $this->userManager, $this->eventDispatcher, $this, null);
+                }
+
+                $group = $this->get($gid);
+                $this->emit('\OC\Group', 'postCreate', [$group]);
+                $this->eventDispatcher->dispatch(new GenericEvent($group, ['gid' => $gid]), 'group.postCreate');
+                return $group;
+            }
+
+            return null;
+        }
+    }
+
+    /**
+     * @param string $gid
+     * @return \OC\Group\Group|null
+     */
+    function get($gid)
+    {
+        if (isset($this->cachedGroups[$gid])) {
+            return $this->cachedGroups[$gid];
+        }
+        return $this->groupManager->get($gid);
+    }
+
+    /**
+     * Get the active backends
+     * @return \OCP\GroupInterface[]
+     */
+    public function getBackends()
+    {
+        return $this->groupManager->getBackends();
+    }
+
+}


### PR DESCRIPTION
instead of calling groupManager->get($gid);
now we are instantiating a new Group object directly in `handleUpdateGroup`
```php
    private function getGroupObject(string $groupId): Group {
        return new Group($groupId, [$this->groupBackend], $this->userManager, $this->eventDispatcher, $this->groupManager, $groupId);
    }
```
```php
private function handleUpdateGroup(string $groupId, $obj) {
        $group = $this->getGroupObject($groupId);
		...
}
```
plus some refactoring to cleanup getGroup/s


issue link: https://github.com/SURFnet/rd-sram-integration/issues/197